### PR TITLE
Do not error if a new branch is created, and also return the current status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,11 @@ outputs:
     description: "`yes|no` depending on if the message should be sent"
     value: ${{ steps.determine-notification.outputs.should_send_message }}
   last_status:
-    description: "status of the last completed workflow"
+    description: "status of the previously completed workflow (or null)"
     value: ${{ steps.determine-notification.outputs.last_status }}
+  current_status:
+    description: "status of the current workflow"
+    value: ${{ steps.determine-notification.outputs.current_status }}
 runs:
   using: "composite"
   steps:
@@ -52,6 +55,8 @@ runs:
         else
             current_status=success
         fi
+        echo "status of the current build: $current_status"
+        echo "::set-output name=current_status::$current_status"
         if [[ "${{ inputs.notify_on_changed_status }}" ]]; then
             if [[ $current_status == $last_status ]]; then
               echo "::set-output name=should_send_message::no"

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
         last_status=$(curl --silent --header 'authorization: Bearer ${{ inputs.github_token }}' \
                       --header 'content-type: application/json' \
                       "https://api.github.com/repos/${{ github.repository }}/actions/workflows/$workflow_id/runs?per_page=1&status=completed&branch=${{ inputs.branch }}" | jq -r .workflow_runs[0].conclusion)
-        if [[  $last_status != success && $last_status != failure ]]; then
+        if [[  $last_status != success && $last_status != failure && $last_status != null ]]; then
             echo "Invalid \$last_status: $last_status"
             exit 1
         else


### PR DESCRIPTION
Instead:
* if notify-on-change, then a new branch should notify.
* if not notify-on-change, then a new branch should only notify if it fails

Should a new branch always notify?